### PR TITLE
The parser should accept "1" and "0" as boolean

### DIFF
--- a/llrp4j-core/src/main/java/net/enilink/llrp4j/types/XmlTypes.java
+++ b/llrp4j-core/src/main/java/net/enilink/llrp4j/types/XmlTypes.java
@@ -149,7 +149,7 @@ public class XmlTypes {
 		int radix = format == FieldFormat.HEX ? 16 : 10;
 		switch (fieldType) {
 		case U_1:
-			return new Boolean(s);
+			return "1".equals(s) ? Boolean.TRUE : Boolean.valueOf(s);
 		case U_2:
 			return Integer.valueOf(s, radix);
 		case U_1_V: {


### PR DESCRIPTION
When mashalling an object as XML, boolean properties are formatted correctly as "1" and "0". I think the parser as well should consider "1" as a `Boolean.TRUE` when unmarshalling.
With this change, both "1" and "true" (case ins.) are parsed as true, and everything else is parsed as false.