### PR TITLE
Thread leak in LlrpClient when connection attempt fails

### DIFF
--- a/llrp4j-net/src/main/java/net/enilink/llrp4j/net/LlrpClient.java
+++ b/llrp4j-net/src/main/java/net/enilink/llrp4j/net/LlrpClient.java
@@ -16,7 +16,12 @@ public class LlrpClient implements Closeable {
 		handler = createHandler(context);
 		nioClient = new NioClient(InetAddress.getByName(host), port, handler, timeout);
 		new Thread(nioClient).start();
-		handler.awaitConnectionAttemptEvent(timeout);
+		try {
+			handler.awaitConnectionAttemptEvent(timeout);
+		} catch(RuntimeException ex) {
+			nioClient.close();
+			throw ex;
+		}
 	}
 
 	private IoHandler createHandler(LlrpContext context) {

--- a/llrp4j-net/src/main/java/net/enilink/llrp4j/net/NioClient.java
+++ b/llrp4j-net/src/main/java/net/enilink/llrp4j/net/NioClient.java
@@ -232,10 +232,14 @@ class NioClient implements Runnable, AutoCloseable {
 	}
 
 	public void close() throws IOException {
-		if (channel != null) {
-			channel.close();
-			channel = null;
+	  try {
+			if (channel != null) {
+				channel.close();
+				channel = null;
+			}
+		} finally {
+			// Closing the selector exits the client loop thread 
+			selector.close();
 		}
-		selector.close();
 	}
 }

--- a/llrp4j-net/src/main/java/net/enilink/llrp4j/net/NioClient.java
+++ b/llrp4j-net/src/main/java/net/enilink/llrp4j/net/NioClient.java
@@ -232,7 +232,7 @@ class NioClient implements Runnable, AutoCloseable {
 	}
 
 	public void close() throws IOException {
-	  try {
+		try {
 			if (channel != null) {
 				channel.close();
 				channel = null;


### PR DESCRIPTION
Hello, i've found a thread leak in `LlrpClient`, that happens when the call to `handler.awaitConnectionAttemptEvent()` throws an exception. The most common case is when you try to connect to an Impinj reader and it responds with:
`"Failed_A_Client_Initiated_Connection_Already_Exists"`
(this is because impinj readers only accept one client connection at a time).
As you can see from the code, when `awaitConnectionAttemptEvent` throws an exception, the client loop thread is already started, and the application code never gets the `LlrpClient` instance, so there is no way to close the selector inside `NioClient`, which would break the loop and let the client thread terminate.
I was implementing an auto-reconnect feature in my application code, and i ended up with thousands of active threads which finally led to an OOME and a jvm shutdown :-D
The proposed fix simply catches the exception and calls `close()`. I've also added a try/finally around `channel.close()` in `NioClient`, just to be sure the selector gets always closed.