### PR TITLE
Connection timeout parameter is ignored

### DIFF
--- a/llrp4j-net/src/main/java/net/enilink/llrp4j/net/NioClient.java
+++ b/llrp4j-net/src/main/java/net/enilink/llrp4j/net/NioClient.java
@@ -190,13 +190,17 @@ class NioClient implements Runnable, AutoCloseable {
 
 	private SocketChannel initConnection(boolean connectBlocking, int timeout) throws IOException {
 		SocketChannel socketChannel = SocketChannel.open();
-		if (!connectBlocking) {
-			socketChannel.configureBlocking(false);
-		}
+		socketChannel.configureBlocking(connectBlocking);
 
 		// Kick off connection establishment
 		try {
-			socketChannel.socket().connect(new InetSocketAddress(this.hostAddress, this.port), timeout);
+			if (connectBlocking) {
+				// When in blocking mode, call connect on the underlying socket
+				// to be able to specify connection timeout.
+				socketChannel.socket().connect(new InetSocketAddress(this.hostAddress, this.port), timeout);
+			} else {
+				socketChannel.connect(new InetSocketAddress(this.hostAddress, this.port));
+			}
 		} catch (IOException e) {
 			socketChannel.close();
 			throw e;

--- a/llrp4j-net/src/main/java/net/enilink/llrp4j/net/NioClient.java
+++ b/llrp4j-net/src/main/java/net/enilink/llrp4j/net/NioClient.java
@@ -192,13 +192,11 @@ class NioClient implements Runnable, AutoCloseable {
 		SocketChannel socketChannel = SocketChannel.open();
 		if (!connectBlocking) {
 			socketChannel.configureBlocking(false);
-		} else {
-			socketChannel.socket().setSoTimeout(timeout);
 		}
 
 		// Kick off connection establishment
 		try {
-			socketChannel.connect(new InetSocketAddress(this.hostAddress, this.port));
+			socketChannel.socket().connect(new InetSocketAddress(this.hostAddress, this.port), timeout);
 		} catch (IOException e) {
 			socketChannel.close();
 			throw e;


### PR DESCRIPTION
The `LlrpClient.create` method takes a `timeout` parameter, but it is actually ignored in `NioClient` when connecting to the reader. The `NioClient.initConnection` method passes the specified timeout value to `setSoTimeout` which is not used for connection timeout, but only when reading from a stream, as per this article:
https://technfun.wordpress.com/2009/01/29/networking-in-java-non-blocking-nio-blocking-nio-and-io/

> The only difference between “blocking NIO” and “NIO wrapped around IO” is that you can’t use socket timeout with SocketChannels. Why ? Read a javadoc for setSocketTimeout(). It says that this timeout is used only by streams.

Actually, the `SocketChannel.connect` doesn't provide any way to specify a connection timeout, so in this PR, i've used instead the connect method from the underlying `Socket`, and it seems to work fine.
I've also removed the `else` branch with the `setSoTimeout` call, since it is ignored in the connection phase, and it gets overwritten anyway in the next `if` block. 