### PR TITLE
Fix voor Java9 ByteBuffer exception on Java 8 or lower

### DIFF
--- a/llrp4j-net/src/main/java/net/enilink/llrp4j/net/NioClient.java
+++ b/llrp4j-net/src/main/java/net/enilink/llrp4j/net/NioClient.java
@@ -3,6 +3,7 @@ package net.enilink.llrp4j.net;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
@@ -120,7 +121,7 @@ class NioClient implements Runnable, AutoCloseable {
 		SocketChannel socketChannel = (SocketChannel) key.channel();
 
 		// Clear out our read buffer so it's ready for new data
-		this.readBuffer.clear();
+		((Buffer)this.readBuffer).clear();
 
 		// Attempt to read off the channel
 		int numRead;

--- a/llrp4j-net/src/main/java/net/enilink/llrp4j/net/NioServer.java
+++ b/llrp4j-net/src/main/java/net/enilink/llrp4j/net/NioServer.java
@@ -3,6 +3,7 @@ package net.enilink.llrp4j.net;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
@@ -140,7 +141,7 @@ class NioServer implements Runnable {
 		SocketChannel socketChannel = (SocketChannel) key.channel();
 
 		// Clear out our read buffer so it's ready for new data
-		this.readBuffer.clear();
+		((Buffer)this.readBuffer).clear();
 
 		// Attempt to read off the channel
 		int numRead;


### PR DESCRIPTION
Java 9 introduces overridden methods with covariant return types for the following methods in java.nio.ByteBuffer that are used by the driver:
- position
- limit
- flip
- clear

In Java 9 they all now return ByteBuffer, whereas the methods they override return Buffer, 
resulting in exceptions like this when executing on Java 8 and lower:

`java.lang.NoSuchMethodError: java.nio.ByteBuffer.limit(I)Ljava/nio/ByteBuffer`

This is because the generated byte code includes the static return type of the method, which is not found on Java 8 and lower because the overloaded methods with covariant return types don't exist.

The solution is to cast ByteBuffer instances to Buffer before calling the method.